### PR TITLE
Pass --lang option to clj-kondo

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,12 @@ export default {
         const editorText = textEditor.getText();
         const [extension] = editorPath.match(/\.\w+$/gi) || [];
 
-        const command = "--lint";
+        const args = ["--lint"];
+        args.push(`--lang ${extension}`);
+        args.push("-");
 
         return helpers
-          .exec(kondoExecutablePath, [command, "-"], {
+          .exec(kondoExecutablePath, args, {
             cwd: dirname(editorPath),
             uniqueKey: linterName,
             stdin: editorText,

--- a/index.js
+++ b/index.js
@@ -43,9 +43,7 @@ export default {
         const editorText = textEditor.getText();
         const [extension] = editorPath.match(/\.\w+$/gi) || [];
 
-        const args = ["--lint"];
-        args.push(`--lang ${extension}`);
-        args.push("-");
+        const args = ["--lint", `--lang ${extension}`, "-"];
 
         return helpers
           .exec(kondoExecutablePath, args, {


### PR DESCRIPTION
I asked in the [#clj-kondo channel](https://clojurians.slack.com/archives/CHY97NXE2) in Clojurians Slack:

> Sorry if this is a FAQ, but kondo always produces unresolved symbol
> errors when I open up my `deps.edn` file in my editor. Is there a
> known workaround for this? Or a plan to change it? I don’t quite
> understand the behavior, given that the EDN spec says symbols are
> valid in EDN files, and AFAIK there’s no way within the file to
> provide a way for the symbols to be resolved…

After a little back-and-forth, @borkdude suggested:

> maybe linter-kondo doesn't pass the right `--lang` argument when it
> lints a .edn file. It should pass `--lang edn`

and elaborated:

> [linter-kondo] passes the text via stdin, so clj-kondo doesn't know
> the filename. so it cannot know if your code is edn, clj, cljs etc
>
> this is what the --lang flag is for

Hence this change. I haven’t tested this because I don’t know the dev
workflow for Atom extensions/plugins. Sorry about that. Any assistance
in getting this shipped would be appreciated!

Thanks for the super useful tool!