### PR TITLE
Strip dot before extension, correct arg ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ export default {
         const editorText = textEditor.getText();
         const [extension] = editorPath.match(/\.\w+$/gi) || [];
 
-        const args = ["--lint", `--lang ${extension}`, "-"];
+        const args = ["--lang", extension.substr(1), "--lint", "-"];
 
         return helpers
           .exec(kondoExecutablePath, args, {


### PR DESCRIPTION
Fixes argument passing to kondo to enable language passing

I've tested this change for `.cljs` `.clj` and `.edn`